### PR TITLE
Add TransformDataset to allow dynamically changing data transformations.

### DIFF
--- a/ALBench/dataset/dataset_impl/car_multi_label_dataset.py
+++ b/ALBench/dataset/dataset_impl/car_multi_label_dataset.py
@@ -6,7 +6,7 @@ import os
 from torch.utils.data import Dataset, Subset
 from PIL import Image
 from torchvision import transforms
-from ALBench.skeleton.dataset_skeleton import register_dataset, LabelType
+from ALBench.skeleton.dataset_skeleton import register_dataset, LabelType, TransformDataset
 
 
 def getting_data(url, path):
@@ -67,10 +67,9 @@ class MetaParsing:
 
 
 class CarDataset(Dataset):
-    def __init__(self, transform, data_dir):
+    def __init__(self, data_dir):
         self.labels, self.file_names = MetaParsing(data_dir).parsing()
         assert len(self.labels) == len(self.file_names)
-        self.transform = transform
         self.data_dir = data_dir
 
     def __len__(self):
@@ -79,18 +78,18 @@ class CarDataset(Dataset):
     def __getitem__(self, idx):
         img_loc = os.path.join(os.path.join(self.data_dir, "carimages/car_ims"), self.file_names[idx])
         image = Image.open(img_loc).convert('RGB')
-        single_img = self.transform(image)
 
-        return single_img, self.labels[idx]
+        return image, self.labels[idx]
 
 
 @register_dataset("car_multi_label", LabelType.MULTI_LABEL)
 def get_car_multi_label_dataset(data_dir, *args):
-    dataset = CarDataset(transforms.Compose([
+    transform = transforms.Compose([
         transforms.Resize((224, 224)),
         transforms.ToTensor(),
         transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))
-    ]))
+    ])
+    dataset = CarDataset(data_dir)
     rnd = np.random.RandomState(42)
     idxs = rnd.permutation(len(dataset))
     train_idxs, val_idxs, test_idxs = idxs[:len(dataset) - len(dataset) // 5], \
@@ -98,7 +97,8 @@ def get_car_multi_label_dataset(data_dir, *args):
                                       idxs[-len(dataset) // 10:]
     train_dataset, val_dataset, test_dataset = \
         Subset(dataset, train_idxs), Subset(dataset, val_idxs), Subset(dataset, test_idxs)
-    return train_dataset, val_dataset, test_dataset, dataset.labels[train_idxs], dataset.labels[val_idxs], \
+    return TransformDataset(train_dataset, transform=transform), TransformDataset(val_dataset, transform=transform), \
+           TransformDataset(test_dataset, transform=transform), dataset.labels[train_idxs], dataset.labels[val_idxs], \
            dataset.labels[test_idxs], 10
 
 

--- a/ALBench/dataset/dataset_impl/celeba_dataset.py
+++ b/ALBench/dataset/dataset_impl/celeba_dataset.py
@@ -1,16 +1,17 @@
 from torchvision.datasets import CelebA
 from torchvision import transforms
-from ALBench.skeleton.dataset_skeleton import register_dataset, LabelType
+from ALBench.skeleton.dataset_skeleton import register_dataset, LabelType, TransformDataset
 
 
 @register_dataset("celeb", LabelType.MULTI_LABEL)
 def get_celeb_dataset(data_dir, *args):
     transform = transforms.Compose([transforms.Resize((224, 224)),
                                     transforms.ToTensor()])
-    train_dataset = CelebA(root=data_dir, split="train", target_type="attr", transform=transform, download=True)
-    val_dataset = CelebA(root=data_dir, split="valid", target_type="attr", transform=transform, download=True)
-    test_dataset = CelebA(root=data_dir, split="test", target_type="attr", transform=transform, download=True)
-    return train_dataset, val_dataset, test_dataset, None, None, None, 40
+    train_dataset = CelebA(root=data_dir, split="train", target_type="attr", download=True)
+    val_dataset = CelebA(root=data_dir, split="valid", target_type="attr", download=True)
+    test_dataset = CelebA(root=data_dir, split="test", target_type="attr", download=True)
+    return TransformDataset(train_dataset, transform=transform), TransformDataset(val_dataset, transform=transform), \
+           TransformDataset(test_dataset, transform=transform), None, None, None, 40
 
 
 if __name__ == "__main__":

--- a/ALBench/dataset/dataset_impl/cifar100_dataset.py
+++ b/ALBench/dataset/dataset_impl/cifar100_dataset.py
@@ -4,52 +4,48 @@ from torch.utils.data import Subset
 import numpy as np
 from torchvision import transforms
 from torchvision.datasets import CIFAR100
-from ALBench.skeleton.dataset_skeleton import DatasetOnMemory, LabelType, register_dataset
+from ALBench.skeleton.dataset_skeleton import DatasetOnMemory, LabelType, register_dataset, TransformDataset
 
 
 @register_dataset("cifar100_imb", LabelType.MULTI_CLASS)
 def get_cifar100_imb_dataset(n_class, data_dir, *args):
     train_transform = transforms.Compose([
-        transforms.ToPILImage(),
         transforms.RandomCrop(32, padding=4),
         transforms.RandomHorizontalFlip(),
         transforms.RandomRotation(15),
         transforms.ToTensor(),
-        transforms.Normalize((0.5071, 0.4867, 0.4408), (0.2675, 0.2565, 0.2761))]) 
-    test_transform= transforms.Compose([
+        transforms.Normalize((0.5071, 0.4867, 0.4408), (0.2675, 0.2565, 0.2761))])
+    test_transform = transforms.Compose([
         transforms.ToTensor(),
-        transforms.Normalize((0.5071, 0.4867, 0.4408), (0.2675, 0.2565, 0.2761))])  
+        transforms.Normalize((0.5071, 0.4867, 0.4408), (0.2675, 0.2565, 0.2761))])
     target_transform = transforms.Compose(
         [lambda x: torch.LongTensor([x]),
          lambda x: torch.flatten(F.one_hot(torch.clip(x, min=None, max=n_class - 1), n_class))])
-    train_dataset = CIFAR100(data_dir, train=True, download=True, transform=transforms.ToTensor(),
-                             target_transform=target_transform)
-    test_dataset = CIFAR100(data_dir, train=False, download=True, transform=transforms.ToTensor(),
-                            target_transform=target_transform)
-    train_loader = torch.utils.data.DataLoader(train_dataset, batch_size=len(train_dataset), shuffle=False, num_workers=40)
-    train_imgs, train_labels = next(iter(train_loader))
-    test_loader = torch.utils.data.DataLoader(test_dataset, batch_size=len(test_dataset), shuffle=False, num_workers=40)
-    test_imgs, test_labels = next(iter(test_loader))
-    train_dataset = DatasetOnMemory(train_imgs, train_labels, n_class, transform=train_transform)
-    test_dataset = DatasetOnMemory(test_imgs, test_labels, n_class, transform=test_dataset)
 
+    train_dataset = CIFAR100(data_dir, train=True, download=True, target_transform=target_transform)
+    test_dataset = CIFAR100(data_dir, train=False, download=True, target_transform=target_transform)
 
     rnd = np.random.RandomState(42)
     idxs = rnd.permutation(len(test_dataset))
     val_idxs, test_idxs = idxs[:-len(idxs) // 2], idxs[-len(idxs) // 2:]
 
-    return train_dataset, Subset(test_dataset, val_idxs), Subset(test_dataset, test_idxs), train_labels, \
-           test_labels[val_idxs], test_labels[test_idxs], n_class
+    val_dataset, test_dataset = Subset(test_dataset, val_idxs), Subset(test_dataset, test_idxs)
+
+    return TransformDataset(train_dataset, transform=train_transform), \
+           TransformDataset(val_dataset, transform=test_transform), \
+           TransformDataset(test_dataset, transform=test_transform), None, None, None, n_class
+
 
 @register_dataset("cifar100", LabelType.MULTI_CLASS)
 def get_cifar100_dataset(data_dir, *args):
     n_class = 100
     return get_cifar100_imb_dataset(n_class, data_dir, *args)
 
+
 if __name__ == "__main__":
     from torch.utils.data import DataLoader
 
-    train, val, test, train_labels, val_labels, test_labels, _ = get_cifar100_imb_dataset(3,"./data")
+    train, val, test, train_labels, val_labels, test_labels, _ = get_cifar100_imb_dataset(3, "./data")
     print(len(train), len(val), len(test), train_labels.shape, val_labels.shape, test_labels.shape)
     loader = DataLoader(train, batch_size=2)
     x, y = next(iter(loader))

--- a/ALBench/dataset/dataset_impl/cifar10_dataset.py
+++ b/ALBench/dataset/dataset_impl/cifar10_dataset.py
@@ -4,60 +4,57 @@ from torch.utils.data import Subset
 import numpy as np
 from torchvision import transforms
 from torchvision.datasets import CIFAR10
-from ALBench.skeleton.dataset_skeleton import DatasetOnMemory, register_dataset, LabelType
+from ALBench.skeleton.dataset_skeleton import DatasetOnMemory, register_dataset, LabelType, TransformDataset
 
 
 @register_dataset("cifar10_imb", LabelType.MULTI_CLASS)
-def get_cifar10_imb_dataset(n_class, data_dir,*args):
-    transform = transforms.Compose([
-        transforms.ToPILImage(),
+def get_cifar10_imb_dataset(n_class, data_dir, *args):
+    train_transform = transforms.Compose([
         transforms.RandomCrop(32, padding=4),
         transforms.RandomHorizontalFlip(),
         transforms.ToTensor(),
         transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2470, 0.2435, 0.2616))
     ])
+    test_transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2470, 0.2435, 0.2616))])
     target_transform = transforms.Compose(
         [lambda x: torch.LongTensor([x]),
          lambda x: torch.flatten(F.one_hot(torch.clip(x, min=None, max=n_class - 1), n_class))])
-    train_dataset = CIFAR10(data_dir, train=True, download=True, transform=transforms.ToTensor(), target_transform=target_transform)
-    test_dataset = CIFAR10(data_dir, train=False, download=True, transform=transforms.ToTensor(), target_transform=target_transform)
-    train_loader = torch.utils.data.DataLoader(train_dataset, batch_size=len(train_dataset), shuffle=False, num_workers=40)
-    train_imgs, train_labels = next(iter(train_loader))
-    test_loader = torch.utils.data.DataLoader(test_dataset, batch_size=len(test_dataset), shuffle=False, num_workers=40)
-    test_imgs, test_labels = next(iter(test_loader))
-    train_dataset = DatasetOnMemory(train_imgs, train_labels, n_class, transform=transform)
-    test_dataset = DatasetOnMemory(test_imgs, test_labels, n_class, transform=transform)
+
+    train_dataset = CIFAR10(data_dir, train=True, download=True, target_transform=target_transform)
+    test_dataset = CIFAR10(data_dir, train=False, download=True, target_transform=target_transform)
 
     rnd = np.random.RandomState(42)
     idxs = rnd.permutation(len(test_dataset))
     val_idxs, test_idxs = idxs[:-len(idxs) // 2], idxs[-len(idxs) // 2:]
 
-    return train_dataset, Subset(test_dataset, val_idxs), Subset(test_dataset, test_idxs), train_labels, \
-           test_labels[val_idxs], test_labels[test_idxs], n_class
+    val_dataset, test_dataset = Subset(test_dataset, val_idxs), Subset(test_dataset, test_idxs)
+
+    return TransformDataset(train_dataset, transform=train_transform), \
+           TransformDataset(val_dataset, transform=test_transform), \
+           TransformDataset(test_dataset, transform=test_transform), None, None, None, n_class
 
 
 @register_dataset("cifar10", LabelType.MULTI_CLASS)
 def get_cifar10_dataset(data_dir, *args):
     n_class = 10
-    return get_cifar10_imb_dataset(n_class, data_dir,*args)
-
+    return get_cifar10_imb_dataset(n_class, data_dir, *args)
 
 
 if __name__ == "__main__":
     from torch.utils.data import DataLoader
 
-    train, val, test, train_labels, val_labels, test_labels, _ = get_cifar10_imb_dataset(3,"./data")
+    train, val, test, train_labels, val_labels, test_labels, _ = get_cifar10_imb_dataset(3, "./data")
     print(len(train), len(val), len(test), train_labels.shape, val_labels.shape, test_labels.shape)
     loader = DataLoader(train, batch_size=2)
     x, y = next(iter(loader))
     print(x.size(), y.size())
-    print(x,y)
+    print(x, y)
 
     train, val, test, train_labels, val_labels, test_labels, _ = get_cifar10_dataset("./data")
     print(len(train), len(val), len(test), train_labels.shape, val_labels.shape, test_labels.shape)
     loader = DataLoader(train, batch_size=2)
     x, y = next(iter(loader))
     print(x.size(), y.size())
-    print(x,y)
-
-
+    print(x, y)

--- a/ALBench/dataset/dataset_impl/coco_dataset.py
+++ b/ALBench/dataset/dataset_impl/coco_dataset.py
@@ -6,7 +6,7 @@ import torch
 from torch.utils.data import Dataset, random_split
 import pickle
 from torchvision import transforms
-from ALBench.skeleton.dataset_skeleton import DatasetOnMemory, register_dataset, LabelType
+from ALBench.skeleton.dataset_skeleton import register_dataset, LabelType, TransformDataset
 
 urls = {'train_img': 'http://images.cocodataset.org/zips/train2014.zip',
         'val_img': 'http://images.cocodataset.org/zips/val2014.zip',
@@ -134,8 +134,9 @@ class COCO2014(Dataset):
         target[labels] = 1
         return img, target
 
+
 @register_dataset("coco", LabelType.MULTI_LABEL)
-def get_coco_dataset(data_dir,*args):
+def get_coco_dataset(data_dir, *args):
     train_transform = transforms.Compose([
         transforms.RandomResizedCrop((224, 224), scale=(0.66, 1.5), ratio=(1.0, 1.0)),
         transforms.RandomHorizontalFlip(),
@@ -148,27 +149,28 @@ def get_coco_dataset(data_dir,*args):
         transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
     ])
     file_dir = os.path.join(data_dir, 'coco2014')
-    train_dataset = COCO2014(file_dir, phase="train", transform=train_transform)
-    test_dataset = COCO2014(file_dir, phase="val", transform=test_transform)
-    valid_dataset,test_dataset = random_split(test_dataset,
-                                       [len(test_dataset) // 4, len(test_dataset) - len(test_dataset) // 4],
-                                       generator=torch.Generator().manual_seed(42))
+    train_dataset = COCO2014(file_dir, phase="train")
+    test_dataset = COCO2014(file_dir, phase="val")
+    valid_dataset, test_dataset = random_split(test_dataset,
+                                               [len(test_dataset) // 4, len(test_dataset) - len(test_dataset) // 4],
+                                               generator=torch.Generator().manual_seed(42))
 
-    n_class=train_dataset.num_classes
+    n_class = train_dataset.num_classes
 
-    return train_dataset, valid_dataset, test_dataset, None, None, None, n_class
+    return TransformDataset(train_dataset, transform=train_transform), \
+           TransformDataset(valid_dataset, transform=test_transform), \
+           TransformDataset(test_dataset, transform=test_transform), None, None, None, n_class
 
 
 if __name__ == "__main__":
     from torch.utils.data import DataLoader
 
-    train, val, test, _,_, _, _ = get_coco_dataset("./data")
+    train, val, test, _, _, _, _ = get_coco_dataset("./data")
     print(len(train), len(val), len(test))
     loader = DataLoader(train, batch_size=1)
     img, target = next(iter(loader))
     print(img.size())
     print(target)
     print(target.size())
-    
 
-#[TESTED]
+# [TESTED]

--- a/ALBench/dataset/dataset_impl/imagenet_dataset.py
+++ b/ALBench/dataset/dataset_impl/imagenet_dataset.py
@@ -3,12 +3,13 @@ import requests
 
 import torch
 import torch.nn.functional as F
-from tqdm import tqdm
-from urllib.request import urlretrieve
+from torch.utils.data import Dataset, random_split
 from torchvision import transforms
 from torchvision.datasets import ImageNet
-from ALBench.skeleton.dataset_skeleton import DatasetOnMemory, LabelType, register_dataset
-from torch.utils.data import Dataset, random_split
+from tqdm import tqdm
+from urllib.request import urlretrieve
+from ALBench.skeleton.dataset_skeleton import LabelType, register_dataset, TransformDataset
+
 
 def download_url(url, destination=None, progress_bar=True):
     """Download a URL to a local file.
@@ -48,16 +49,13 @@ def download_url(url, destination=None, progress_bar=True):
         filename, _ = urlretrieve(url, filename=destination)
 
 
-
-
 urls = {'train': 'https://image-net.org/data/ILSVRC/2012/ILSVRC2012_img_train.tar',
         'val': 'https://image-net.org/data/ILSVRC/2012/ILSVRC2012_img_val.tar',
         'test': 'https://image-net.org/data/ILSVRC/2012/ILSVRC2012_img_test_v10102019.tar',
         'dev_kit': 'https://image-net.org/data/ILSVRC/2012/ILSVRC2012_devkit_t12.tar.gz'}
 
 
-def download_imagenet2012(root,phase):
-
+def download_imagenet2012(root, phase):
     url = urls[phase]
     filename = os.path.basename(url)
 
@@ -69,48 +67,48 @@ def download_imagenet2012(root,phase):
 
 
 @register_dataset("imagenet", LabelType.MULTI_CLASS)
-def get_imagenet_dataset(data_dir,*args):
+def get_imagenet_dataset(data_dir, *args):
+    download_imagenet2012(data_dir, "train")
+    download_imagenet2012(data_dir, "val")
+    download_imagenet2012(data_dir, "dev_kit")
 
-    download_imagenet2012(data_dir,"train") 
-    download_imagenet2012(data_dir,"val")
-    download_imagenet2012(data_dir,"dev_kit")
-
-    n_class=1000
-    train_transform =  transforms.Compose([
+    n_class = 1000
+    train_transform = transforms.Compose([
         transforms.RandomResizedCrop(224),
         transforms.RandomHorizontalFlip(),
         transforms.ToTensor(),
         transforms.Normalize(mean=[0.485, 0.456, 0.406],
-                                 std=[0.229, 0.224, 0.225]),
+                             std=[0.229, 0.224, 0.225]),
     ])
     test_transform = transforms.Compose([
-        
         transforms.Resize(256),
         transforms.CenterCrop(224),
         transforms.ToTensor(),
         transforms.Normalize(mean=[0.485, 0.456, 0.406],
-                                 std=[0.229, 0.224, 0.225]),
+                             std=[0.229, 0.224, 0.225]),
     ])
     target_transform = transforms.Compose(
         [lambda x: torch.LongTensor([x]),
          lambda x: torch.flatten(F.one_hot(x, n_class))])
 
-    train_dataset = ImageNet(data_dir, split = "train", transform=train_transform, target_transform=target_transform ) 
-    test_dataset = ImageNet(data_dir, split = "val", transform=test_transform, target_transform=target_transform)
+    train_dataset = ImageNet(data_dir, split="train", target_transform=target_transform)
+    test_dataset = ImageNet(data_dir, split="val", target_transform=target_transform)
 
     print("spliting test dataset into validation and testing")
-    valid_dataset,test_dataset = random_split(test_dataset,
-                                       [len(test_dataset) // 4, len(test_dataset) - len(test_dataset) // 4],
-                                       generator=torch.Generator().manual_seed(42))
-    
+    valid_dataset, test_dataset = random_split(test_dataset,
+                                               [len(test_dataset) // 4, len(test_dataset) - len(test_dataset) // 4],
+                                               generator=torch.Generator().manual_seed(42))
 
-    return train_dataset, valid_dataset, test_dataset, None, None, None, n_class
+    return TransformDataset(train_dataset, transform=train_transform), \
+           TransformDataset(valid_dataset, transform=test_transform), \
+           TransformDataset(test_dataset, transform=test_transform), None, None, None, n_class
+
 
 if __name__ == "__main__":
     from torch.utils.data import DataLoader
 
-    train, val, test, _,_, _, n_class =  get_imagenet_dataset("./data")
-    print(len(train), len(val), len(test),n_class)
+    train, val, test, _, _, _, n_class = get_imagenet_dataset("./data")
+    print(len(train), len(val), len(test), n_class)
     loader = DataLoader(train, batch_size=2)
     x, y = next(iter(loader))
     print(x.size(), y.size())

--- a/ALBench/dataset/dataset_impl/kuzushiji_dataset.py
+++ b/ALBench/dataset/dataset_impl/kuzushiji_dataset.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn.functional as F
 from torch.utils.data import Subset
 from torchvision import transforms
-from ALBench.skeleton.dataset_skeleton import DatasetOnMemory, register_dataset, LabelType
+from ALBench.skeleton.dataset_skeleton import DatasetOnMemory, register_dataset, LabelType, TransformDataset
 
 
 class Kuzushiji49:
@@ -98,37 +98,41 @@ class Kuzushiji49:
                 os.path.exists(os.path.join(self.data_dir, self.test_file_imgs)) and
                 os.path.exists(os.path.join(self.data_dir, self.test_file_labels)))
 
+
 @register_dataset("kuzushiji49", LabelType.MULTI_CLASS)
 def get_kuzushiji49_dataset(data_dir, *args):
-
     n_class = 49
 
     transform = transforms.Compose([
-        transforms.ToPILImage(),
         transforms.Resize(32),
         transforms.ToTensor(),
         transforms.Normalize((0.1307,), (0.3081,)),
         transforms.Lambda(lambda x: x.repeat(3, 1, 1)),
     ])
-    target_transform = transforms.Compose([lambda x: torch.LongTensor([x]), lambda x: torch.flatten(F.one_hot(x, n_class))])
-    train_dataset = Kuzushiji49(data_dir=data_dir, train=True, transform=transforms.ToTensor(), target_transform=target_transform,
-                                download=True)
-    test_dataset = Kuzushiji49(data_dir=data_dir, train=False, transform=transforms.ToTensor(), target_transform=target_transform,
-                               download=True)
+    target_transform = transforms.Compose(
+        [lambda x: torch.LongTensor([x]), lambda x: torch.flatten(F.one_hot(x, n_class))])
+    train_dataset = Kuzushiji49(data_dir=data_dir, train=True, transform=transforms.ToTensor(),
+                                target_transform=target_transform, download=True)
+    test_dataset = Kuzushiji49(data_dir=data_dir, train=False, transform=transforms.ToTensor(),
+                               target_transform=target_transform, download=True)
 
-    train_loader = torch.utils.data.DataLoader(train_dataset, batch_size=len(train_dataset), shuffle=False, num_workers=40)
+    train_loader = torch.utils.data.DataLoader(train_dataset, batch_size=len(train_dataset), shuffle=False,
+                                               num_workers=40)
     train_imgs, train_labels = next(iter(train_loader))
     test_loader = torch.utils.data.DataLoader(test_dataset, batch_size=len(test_dataset), shuffle=False, num_workers=40)
     test_imgs, test_labels = next(iter(test_loader))
-    train_dataset = DatasetOnMemory(train_imgs, train_labels, n_class, transform=transform)
-    test_dataset = DatasetOnMemory(test_imgs, test_labels, n_class, transform=transform)
+    train_dataset = DatasetOnMemory(train_imgs, train_labels, n_class)
+    test_dataset = DatasetOnMemory(test_imgs, test_labels, n_class)
 
     rnd = np.random.RandomState(42)
     idxs = rnd.permutation(len(test_dataset))
     val_idxs, test_idxs = idxs[:-len(idxs) // 2], idxs[-len(idxs) // 2:]
 
-    return train_dataset, Subset(test_dataset, val_idxs), Subset(test_dataset, test_idxs), train_labels, \
-           test_labels[val_idxs], test_labels[test_idxs], n_class
+    val_dataset, test_dataset = Subset(test_dataset, val_idxs), Subset(test_dataset, test_idxs)
+
+    return TransformDataset(train_dataset, transform=transform), TransformDataset(val_dataset, transform=transform), \
+           TransformDataset(test_dataset, transform=transform), train_labels, test_labels[val_idxs], \
+           test_labels[test_idxs], n_class
 
 
 if __name__ == "__main__":

--- a/ALBench/dataset/dataset_impl/voc_dataset.py
+++ b/ALBench/dataset/dataset_impl/voc_dataset.py
@@ -9,9 +9,7 @@ from torch.utils.data import Dataset
 from PIL import Image
 from tqdm import tqdm
 from torchvision import transforms
-from ALBench.skeleton.dataset_skeleton import DatasetOnMemory, register_dataset, LabelType
-
-
+from ALBench.skeleton.dataset_skeleton import register_dataset, LabelType, TransformDataset
 
 object_categories = ['aeroplane', 'bicycle', 'bird', 'boat',
                      'bottle', 'bus', 'car', 'cat', 'chair',
@@ -326,12 +324,11 @@ def download_voc2012(root):
 
 
 class VOC2007(Dataset):
-    def __init__(self, root, phase, transform=None):
+    def __init__(self, root, phase):
         self.root = os.path.abspath(root)
         self.path_devkit = os.path.join(self.root, 'VOCdevkit')
         self.path_images = os.path.join(self.root, 'VOCdevkit', 'VOC2007', 'JPEGImages')
         self.phase = phase
-        self.transform = transform
         download_voc2007(self.root)
 
         # define path of csv file
@@ -356,14 +353,9 @@ class VOC2007(Dataset):
     def __getitem__(self, index):
         filename, target = self.images[index]
         img = Image.open(os.path.join(self.path_images, filename + '.jpg')).convert('RGB')
-        if self.transform is not None:
-            img = self.transform(img)
 
         data = {'image': img, 'name': filename, 'target': target}
         return data
-        # image = {'image': img, 'name': filename}
-        # return image, target
-        # return (img, filename), target
 
     def __len__(self):
         return len(self.images)
@@ -373,12 +365,11 @@ class VOC2007(Dataset):
 
 
 class VOC2012(Dataset):
-    def __init__(self, root, phase, transform=None):
+    def __init__(self, root, phase):
         self.root = os.path.abspath(root)
         self.path_devkit = os.path.join(self.root, 'VOCdevkit')
         self.path_images = os.path.join(self.root, 'VOCdevkit', 'VOC2012', 'JPEGImages')
         self.phase = phase
-        self.transform = transform
         download_voc2012(self.root)
 
         # define path of csv file
@@ -403,8 +394,6 @@ class VOC2012(Dataset):
     def __getitem__(self, index):
         filename, target = self.images[index]
         img = Image.open(os.path.join(self.path_images, filename + '.jpg')).convert('RGB')
-        if self.transform is not None:
-            img = self.transform(img)
         target = (target > 0).float()
         return img, target
 
@@ -416,25 +405,27 @@ class VOC2012(Dataset):
 
 
 @register_dataset("voc", LabelType.MULTI_LABEL)
-def get_voc_dataset(data_dir,*args):
+def get_voc_dataset(data_dir, *args):
     transform = transforms.Compose([
         transforms.Resize((224, 224)),
         transforms.ToTensor(),
         transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
     ])
     file_dir = os.path.join(data_dir, 'coco2014')
-    dataset = VOC2012(file_dir, phase="trainval", transform=transform)
+    dataset = VOC2012(file_dir, phase="trainval")
     n_class = dataset.get_number_classes()
-    train_dataset,valid_dataset, test_dataset = torch.utils.data.random_split(dataset,
-                                                                [10000, (len(dataset) - 10000)//2,(len(dataset) - 10000)//2],
-                                                                generator=torch.Generator().manual_seed(42))
-    return train_dataset, valid_dataset, test_dataset, None, None, None,n_class
+    train_dataset, val_dataset, test_dataset = \
+        torch.utils.data.random_split(dataset, [10000, (len(dataset) - 10000) // 2, (len(dataset) - 10000) // 2],
+                                      generator=torch.Generator().manual_seed(42))
+    return TransformDataset(train_dataset, transform=transform), TransformDataset(val_dataset, transform=transform), \
+           TransformDataset(test_dataset, transform=transform), None, None, None, n_class
 
 
 if __name__ == "__main__":
     from torch.utils.data import DataLoader
+
     train, val, test, _, _, _, n_class = get_voc_dataset("./data")
-    print(len(train), len(test),n_class)
+    print(len(train), len(test), n_class)
     loader = DataLoader(test, batch_size=2)
     img, target = next(iter(loader))
     print(img.size())

--- a/ALBench/dataset/datasets.py
+++ b/ALBench/dataset/datasets.py
@@ -12,6 +12,7 @@ def get_dataset(name, data_dir):
     if n_class is None:
         train_dataset, val_dataset, test_dataset, train_labels, val_labels, test_labels, num_classes = get_fn(data_dir)
     else:
-        train_dataset, val_dataset, test_dataset, train_labels, val_labels, test_labels, num_classes = get_fn(n_class, data_dir)
+        train_dataset, val_dataset, test_dataset, train_labels, val_labels, test_labels, num_classes = get_fn(n_class,
+                                                                                                              data_dir)
     return ALDataset(train_dataset, val_dataset, test_dataset, train_labels, val_labels, test_labels, data_type,
                      num_classes)

--- a/ALBench/skeleton/dataset_skeleton.py
+++ b/ALBench/skeleton/dataset_skeleton.py
@@ -1,6 +1,7 @@
 from enum import Enum
 import numpy as np
 from torch.utils.data import DataLoader, Dataset
+from torchvision import transforms
 import torch
 
 
@@ -47,25 +48,58 @@ class DatasetOnMemory(Dataset):
     A PyTorch dataset where all data lives on CPU memory.
     """
 
-    def __init__(self, X, y, n_class, transform=None, target_transform=None):
+    def __init__(self, X, y, n_class):
         self.X = X
         self.y = y
         assert len(self.X) == len(self.y)
         self.n_class = n_class
-        self.transform = transform
-        self.target_transform = target_transform
 
     def __len__(self):
         return len(self.y)
 
     def __getitem__(self, item):
-        x = self.X[item]
+        x = transforms.ToPILImage()(self.X[item])
         y = self.y[item]
-        if self.transform:
-            x = self.transform(x)
-        if self.target_transform:
-            y = self.target_transform(y)
         return x, y
+
+
+class TransformDataset(Dataset):
+    """
+    A PyTorch Dataset where you can dynamically set transforms.
+
+    Be careful about its behavior when combined with dataloaders!
+    See https://discuss.pytorch.org/t/changing-transformation-applied-to-data-during-training/15671 for details.
+    """
+
+    def __init__(self, dataset, transform=None, target_transform=None):
+        self.dataset = dataset
+        self.__transform = transform
+        self.__target_transform = target_transform
+        self.__default_transform = transform
+        self.__default_target_transform = target_transform
+
+    def __len__(self):
+        return len(self.dataset)
+
+    def __getitem__(self, item):
+        x, y = self.dataset[item]
+        if self.__transform:
+            x = self.__transform(x)
+        if self.__target_transform:
+            y = self.__target_transform(y)
+        return x, y
+
+    def set_transform(self, transform):
+        self.__transform = transform
+
+    def set_target_transform(self, target_transform):
+        self.__target_transform = target_transform
+
+    def set_to_default_transform(self):
+        self.__transform = self.__default_transform
+
+    def set_to_default_target_transform(self):
+        self.__target_transform = self.__default_target_transform
 
 
 class ALDataset:
@@ -86,6 +120,9 @@ class ALDataset:
         :param LabelType label_type: Type of labels.
         :param int num_classes: Number of classes of the dataset.
         """
+        assert isinstance(train_dataset, TransformDataset), "Training dataset must be a TransformDataset."
+        assert isinstance(val_dataset, TransformDataset), "Validation dataset must be a TransformDataset."
+        assert isinstance(test_dataset, TransformDataset), "Test dataset must be a TransformDataset."
         self.train_dataset = train_dataset
         self.val_dataset = val_dataset
         self.test_dataset = test_dataset


### PR DESCRIPTION
1. Added a wrapper for PyTorch datasets so we can dynamically set the data transformations. Be careful about its behavior when combined with Dataloaders! Specifically, every time you set the transform, you should create a new Dataloader. See more information at: https://discuss.pytorch.org/t/changing-transformation-applied-to-data-during-training/15671.
2. Removed DatasetOnMemory wrapper for CIFAR10, CIFAR100 and SVHN as the pytorch dataset already stores data on memory.