### PR TITLE
Add entropy and margin sampling strategies.

### DIFF
--- a/ALBench/strategy/strategy_impl/entropy_sampling.py
+++ b/ALBench/strategy/strategy_impl/entropy_sampling.py
@@ -1,0 +1,31 @@
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from ALBench.skeleton.active_learning_skeleton import Strategy, ALInput
+
+
+class EntropySampling(Strategy):
+    strategy_name = "entropy"
+
+    def __init__(self, strategy_config, dataset):
+        super(EntropySampling, self).__init__(strategy_config, dataset)
+        self.input_types = {ALInput.TRAIN_PRED}
+
+    def select(self, trainer, budget):
+        preds = trainer.retrieve_inputs(self.input_types)[0]
+        labeled_set = set(list(self.dataset.labeled_idxs()))
+        all_set = set(list(range(len(self.dataset))))
+        unlabeled = np.array(list(all_set - labeled_set))
+        n_class = preds.shape[1]
+        if n_class > 2:
+            preds_unlabeled = preds[unlabeled]
+            # Clip probability scores for numerical stability.
+            log_preds = np.log2(np.clip(preds_unlabeled, a_min=1e-10, a_max=None))
+            # Compute negative entropy.
+            entropy = np.sum(log_preds * preds_unlabeled, axis=-1)
+        else:
+            # Not exactly entropy, but with the same ranking information.
+            entropy = np.abs(preds[unlabeled, 0] - .5)
+        top_idxs = unlabeled[np.argsort(entropy)[:budget]]
+        return top_idxs

--- a/ALBench/strategy/strategy_impl/margin_sampling.py
+++ b/ALBench/strategy/strategy_impl/margin_sampling.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from ALBench.skeleton.active_learning_skeleton import Strategy, ALInput
+
+
+class MarginSampling(Strategy):
+    strategy_name = "margin"
+
+    def __init__(self, strategy_config, dataset):
+        super(MarginSampling, self).__init__(strategy_config, dataset)
+        self.input_types = {ALInput.TRAIN_PRED}
+
+    def select(self, trainer, budget):
+        preds = trainer.retrieve_inputs(self.input_types)[0]
+        labeled_set = set(list(self.dataset.labeled_idxs()))
+        all_set = set(list(range(len(self.dataset))))
+        unlabeled = np.array(list(all_set - labeled_set))
+        n_class = preds.shape[1]
+        if n_class > 2:
+            preds_unlabeled = preds[unlabeled]
+            preds_sorted = -np.sort(-preds_unlabeled, axis=-1)
+            margin = preds_sorted[:, 0] - preds_sorted[:, 1]
+        else:
+            # Not exactly margin, but with the same ranking information.
+            margin = np.abs(preds[unlabeled, 0] - .5)
+        top_idxs = unlabeled[np.argsort(margin)[:budget]]
+        return top_idxs

--- a/configs/strategy/entropy_sampling.json
+++ b/configs/strategy/entropy_sampling.json
@@ -1,0 +1,3 @@
+{
+  "strategy_name" : "entropy"
+}

--- a/configs/strategy/margin_sampling.json
+++ b/configs/strategy/margin_sampling.json
@@ -1,0 +1,3 @@
+{
+  "strategy_name" : "margin"
+}


### PR DESCRIPTION
add entropy and margin sampling.

I add `preds = F.softmax(torch.from_numpy(preds), dim=1).detach().cpu().numpy()` in entropy sampling since I don't think the current `preds` gives probabilities after softmax.

See results on wandb.