### PR TITLE
Added arXiv paper link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # LabelBench: A Comprehensive Framework for Benchmarking Label-Efficient Learning
+
+[Link to the original paper on arXiv](https://arxiv.org/abs/2306.09910)
+
 Welcome to LabelBench, where we evaluate label-efficient learning performance with a 
 concerted combination of large pretrained models, semi-supervised learning and active
 learning algorithms. We encourage researchers to contribute datasets, pretrained models,


### PR DESCRIPTION
This PR addresses issue #42 by adding a direct link to the original research paper on arXiv in the README.md file. The link is positioned at the top of the README, right below the project's title, ensuring that visitors can quickly find and access the paper for more in-depth details about the project.

**Changes:**
Added the arXiv paper link below the project title in `README.md`.

**Motivation:**
Connecting the GitHub repository directly with the original research paper provides valuable context for visitors and contributors. It also ensures that the foundational work is appropriately credited and easily accessible.

**Testing:**
Previewed the `README.md` on GitHub to ensure that the link renders correctly and directs to the correct arXiv paper.